### PR TITLE
Finish provider renaming to leverage go get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ribbybibby/terraform-provider-hiera
+module github.com/SmilingNavern/terraform-provider-gohiera
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/ribbybibby/terraform-provider-hiera/hiera"
+	"github.com/SmilingNavern/terraform-provider-gohiera/hiera"
 )
 
 func main() {


### PR DESCRIPTION
There are some leftovers from original provider that avoids a clean `go get`.

The objetive of this PR is to fix go get errors and ease provider install.

If you do a `go get` against current master you end with these errors:
```
go: finding github.com/SmilingNavern/terraform-provider-gohiera latest
go: downloading github.com/SmilingNavern/terraform-provider-gohiera v0.0.0-20190830100322-89c94245a80d
go: extracting github.com/SmilingNavern/terraform-provider-gohiera v0.0.0-20190830100322-89c94245a80d
go get: github.com/SmilingNavern/terraform-provider-gohiera@v0.0.0-20190830100322-89c94245a80d: parsing go.mod:
	module declares its path as: github.com/ribbybibby/terraform-provider-hiera
	        but was required as: github.com/SmilingNavern/terraform-provider-gohiera
```

Here is an small Dockerfile to test-it:
```
FROM golang:alpine


# Since alpine doesn't have gcc
RUN apk add --no-cache \
     gcc \
     git \
     musl-dev \
     openssl \
  && mkdir -p $HOME/go \
  && export GOPATH=$HOME/go \
  && export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin \
  && export GO111MODULE=on \
  && go get -v github.com/SmilingNavern/terraform-provider-gohiera \
  && ls -lah . \
  && ls -lah $GOPATH \
  && ls -lah $GOPATH/bin

```